### PR TITLE
Make cachecnotrol 0.12.14 available

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.13.0" %}
+{% set version = "0.12.14" %}
 
 package:
   name: cachecontrol-split
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/C/CacheControl/CacheControl-{{ version }}.tar.gz
-  sha256: fd3fd2cb0ca66b9a6c1d56cc9709e7e49c63dbd19b1b1bcbd8d3f94cedfe8ce5
+  sha256: d1087f45781c0e00616479bfd282c78504371ca71da017b49df9f5365a95feba
 
 build:
   number: 0


### PR DESCRIPTION
According to https://github.com/psf/cachecontrol/issues/311#issuecomment-1580971923, there is an important fix on the old interface version 0.12.14, and it would be nice to have this version on conda too. 0.13.0 is, according to the issue above, a "new" different interface.

Actually, version 0.12.14 is newer than 0.13.0

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
